### PR TITLE
Twine Script + Manifest file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+global-include *

--- a/uploadpypi.sh
+++ b/uploadpypi.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+python3 setup.py sdist
+twine upload dist/*


### PR DESCRIPTION
This pull request includes the missing manifest file in order for python to recursively include source files (c/cpp/txt files) that is required for pip to compile

Additionally, I have made a script that basically bundles it into a source + uploads to pypi! 

This should also work with as it complained about missing MANIFEST.in when required for compiling 

`pip3 install git+https://github.com/andrewtrotman/JASSv2.git`
