### PR TITLE
Fixed Setup.py for Big Sur + pythonic wheels way

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,10 +69,10 @@ class CMakeBuild(build_ext):
 setup(
     cmdclass=dict(build_ext=CMakeBuild),
     name='pyjass',
-    version='0.1.1',
+    version='0.1.2',
     author='Andrew Trotman',
-    description='Some short description about the stuff goes here',
-    long_description='refer to github for details',
+    description='The JASS experimental Score-at-a-Time search engine.',
+    long_description='Please visit https://github.com/andrewtrotman/JASSv2 ',
     include_dirs =[''],
     author_email='andrew@cs.otago.ac.nz',
     download_url='',
@@ -90,6 +90,7 @@ setup(
        'Operating System :: POSIX :: Linux', # WSL will be treated as Linux so it's not a problem
    ],
    python_requires='>=3.4',
+   install_requires=['wheel>0.35','packaging>20'],
    ext_modules=[CMakeExtension("dummy")] # force python to generate a dummy.so/pyc bindings - cmake script takes care of that
    
 )


### PR DESCRIPTION
Hi,

This is to fix the issue found on Big Sur which is caused by wheels and packaging. Therefore, because `MACOSX_DEPLOYMENT_TARGET `typically specifies a major macOS version, it is now natural to have `MACOSX_DEPLOYMENT_TARGET=11.` This is accepted by all system build tools and compilers.

This is not a problem on conda as conda behind the scenes does `MACOSX_DEPLOYMENT_TARGET=10.` and forces to build for 10.9

This causes issues for python that is natively compiled by brew or pre-installed with the system. To handle these wheels was upgraded. So in this setup.py we do additional checks:-

1. Ensuring wheels > 0.35 and packaging > 0.21
2. Added a check on Darwin (mac - so we create a dummy so file)

Tested on - anaconda/Big Sur and Google Cloud VM

