### PR TITLE
GCC 11.2

### DIFF
--- a/tools/test_integer_compress.cpp
+++ b/tools/test_integer_compress.cpp
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include <atomic>
 #include <limits>

--- a/tools/test_integer_compress_average.cpp
+++ b/tools/test_integer_compress_average.cpp
@@ -30,12 +30,13 @@
 	so the columns are not individual runs.
 */
 #include <stdio.h>
-#include <inttypes.h>
+#include <stdint.h>
 
 #include <map>
 #include <vector>
 #include <iostream>
 #include <algorithm>
+#include <cinttypes>
 
 #include "file.h"
 


### PR DESCRIPTION
GCC 11.2 compiler on conda 4.11 (linux) throws a compile error when pip install pyjass is being executed.  This was fixed to handle GCC 11.2x

Fixed by @andrewtrotman , just creating a PR to have it merged to main 