### PR TITLE
Specify ATIRE_DIR with same case as repo

### DIFF
--- a/JASSv1/GNUmakefile
+++ b/JASSv1/GNUmakefile
@@ -1,4 +1,4 @@
-ATIRE_DIR = ../../atire
+ATIRE_DIR = ../../ATIRE
 
 ATIRE_OBJ = \
 	$(ATIRE_DIR)/obj/stats.o			\


### PR DESCRIPTION
These should match as by default new users will be cloning the ATIRE repo without renaming. Especially important on Linux and other operating systems with case-sensitive filesystems