### PR TITLE
Faster heap comparison (WIP)

### DIFF
--- a/source/query_heap_clean.h
+++ b/source/query_heap_clean.h
@@ -304,48 +304,39 @@ namespace JASS
 					By doing the add first its possible to reduce the "usual" path through the code to a single comparison.  The JASS v1 "usual" path took three comparisons.
 				*/ \
 				*which.pointer() += _score; \
-				if (*which.pointer() >= top_k_lower_bound) \
+				if (*which.pointer() < top_k_lower_bound) \
+					continue; \
+				if (needed_for_top_k > 0) \
 					{ \
-					if (which >= accumulator_pointers[0])			/* == is the case where we're the current bottom of heap so might need to be promoted */ \
-						{	\
-						/*
-							We end up in the top-k, now to work out why.  As this is a rare occurence, we've got a little bit of time on our hands
-						*/ \
-						if (needed_for_top_k > 0) \
+					if (*which.pointer() - _score < top_k_lower_bound) \
+						{ \
+						accumulator_pointers[--needed_for_top_k] = which; \
+						if (needed_for_top_k == 0) \
 							{ \
-							/*
-								the heap isn't full yet - so change only happens if we're a new addition (i.e. the old value was a 0)
-							*/ \
-							if (*which.pointer() - _score < top_k_lower_bound) \
-								{ \
-								accumulator_pointers[--needed_for_top_k] = which; \
-								if (needed_for_top_k == 0) \
-									{ \
-									top_results.make_heap(); \
-									if (top_k_lower_bound != 1) \
-										break; /* We must be using the Oracle, and we must have filled the top-k and so we can stop processing this query. */ \
-									top_k_lower_bound = *accumulator_pointers[0];		/* set the new bottom of heap value */ \
-									} \
-								} \
-							} \
-						else \
-							{ \
-							*which.pointer() -= _score; \
-							if (which < accumulator_pointers[0]) \
-								{ \
-								*which.pointer() += _score;					/* we weren't in there before but we are now so replace element 0 */ \
-								top_results.push_back(which);				/* we're not in the heap so add this accumulator to the heap */ \
-								} \
-							else \
-								{ \
-								auto at = top_results.find(which);		/* we're already in there so find us and reshuffle the beap. */ \
-								*which.pointer() += _score; \
-								top_results.promote(which, at);				/* we're already in the heap so promote this document */ \
-								} \
-							top_k_lower_bound = *accumulator_pointers[0];			/* set the new bottom of heap value */ \
+							top_results.make_heap(); \
+							if (top_k_lower_bound != 1) \
+								break; \
+							top_k_lower_bound = *accumulator_pointers[0]; \
 							} \
 						} \
+					continue; \
 					} \
+				if (*which.pointer() == top_k_lower_bound) \
+					{ \
+					if (which.pointer() < accumulator_pointers[0].pointer()) \
+						continue; \
+					top_results.push_back(which); \
+					top_k_lower_bound = *accumulator_pointers[0]; \
+					continue; \
+					} \
+				if (*which.pointer() - _score < top_k_lower_bound || (*which.pointer() - _score == top_k_lower_bound && which.pointer() < accumulator_pointers[0].pointer())) \
+					top_results.push_back(which); \
+				else \
+					{ \
+					auto at = top_results.find(which); \
+					top_results.promote(which, at); \
+					} \
+				top_k_lower_bound = *accumulator_pointers[0]; \
 				}
 
 			/*
@@ -409,52 +400,7 @@ namespace JASS
 				#pragma GCC unroll 8
 #endif
 				for (DOCID_TYPE *current = buffer; current < end; current++)
-					{
-					ACCUMULATOR_TYPE _score = impact;
-					accumulator_pointer which = &accumulators[*current];
-
-					*which.pointer() += _score;
-
-					if (*which.pointer() < top_k_lower_bound)
-						continue;
-					if (needed_for_top_k > 0)
-						{
-						if (*which.pointer() - _score < top_k_lower_bound)
-							{
-							accumulator_pointers[--needed_for_top_k] = which;
-							if (needed_for_top_k == 0)
-								{
-								top_results.make_heap();
-								if (top_k_lower_bound != 1)
-									break;
-								top_k_lower_bound = *accumulator_pointers[0];
-								}
-							}
-						continue;
-						}
-					if (*which.pointer() == top_k_lower_bound)
-						{
-						if (which.pointer() < accumulator_pointers[0].pointer())
-							continue;
-						top_results.push_back(which);
-						top_k_lower_bound = *accumulator_pointers[0];
-						continue;
-						}
-					if (*which.pointer() - _score < top_k_lower_bound)
-						{
-						top_results.push_back(which);
-						}
-					else if (*which.pointer() - _score == top_k_lower_bound && which.pointer() < accumulator_pointers[0].pointer())
-						{
-						top_results.push_back(which);
-						}
-					else
-						{
-						auto at = top_results.find(which);
-						top_results.promote(which, at);
-						}
-					top_k_lower_bound = *accumulator_pointers[0];
-					}
+					ADD_RSV(*current, impact);
 				}
 
 			/*

--- a/source/query_heap_clean.h
+++ b/source/query_heap_clean.h
@@ -300,14 +300,20 @@ namespace JASS
 				{ \
 				ACCUMULATOR_TYPE _score = SCORE;\
 				accumulator_pointer which = &accumulators[(DOCUMENT_ID)];			/* This will create the accumulator if it doesn't already exist. */ \
-				/*
-					By doing the add first its possible to reduce the "usual" path through the code to a single comparison.  The JASS v1 "usual" path took three comparisons.
-				*/ \
 				*which.pointer() += _score; \
+				/*
+					accumulator is less than the heap entry value
+				*/ \
 				if (*which.pointer() < top_k_lower_bound) \
 					continue; \
+				/*
+					the heap isn't full yet - so change only happens if we're a new addition (i.e. the old value was a 0)
+				*/ \
 				if (needed_for_top_k > 0) \
 					{ \
+					/*
+						we weren't already in the heap
+					*/ \
 					if (*which.pointer() - _score < top_k_lower_bound) \
 						{ \
 						accumulator_pointers[--needed_for_top_k] = which; \
@@ -315,28 +321,36 @@ namespace JASS
 							{ \
 							top_results.make_heap(); \
 							if (top_k_lower_bound != 1) \
-								break; \
-							top_k_lower_bound = *accumulator_pointers[0]; \
+								break; /* We must be using the Oracle, and we must have filled the top-k and so we can stop processing this query. */ \
+							top_k_lower_bound = *accumulator_pointers[0]; /* set the new bottom of heap value */ \
 							} \
 						} \
 					continue; \
 					} \
+				/*
+					accumulator is equal to the heap entry value, now we need to tie break
+				*/ \
 				if (*which.pointer() == top_k_lower_bound) \
 					{ \
 					if (which.pointer() < accumulator_pointers[0].pointer()) \
 						continue; \
-					top_results.push_back(which); \
+					top_results.push_back(which); /* we're not in the heap so add this accumulator to the heap */ \
 					top_k_lower_bound = *accumulator_pointers[0]; \
 					continue; \
 					} \
+				/*
+					accumulator exceeds the heap entry value, we now need to figure out if the accumulator was already in the heap
+					if the old value didn't exceed the heap entry, or it was equal and we failed the tie-break then we weren't in it
+					otherwise we were and need to be promoted
+				*/ \
 				if (*which.pointer() - _score < top_k_lower_bound || (*which.pointer() - _score == top_k_lower_bound && which.pointer() < accumulator_pointers[0].pointer())) \
 					top_results.push_back(which); \
 				else \
 					{ \
-					auto at = top_results.find(which); \
-					top_results.promote(which, at); \
+					auto at = top_results.find(which); /* we're already in there so find us and reshuffle the heap. */ \
+					top_results.promote(which, at); /* we're already in the heap so promote this document */ \
 					} \
-				top_k_lower_bound = *accumulator_pointers[0]; \
+				top_k_lower_bound = *accumulator_pointers[0]; /* set the new bottom of heap value */ \
 				}
 
 			/*


### PR DESCRIPTION
Improves the performance of accumulator comparison for heap entry. Timings are for wall clock time when executing 60,000 queries on Gov2 (25 million documents)

| Before | After |
| - | - |
| 36m57s | 35m51s |

Testing:
* Same ranking as before when run on 500 queries