### PR TITLE
Allow inlined function instead of macro by using exception for break

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -140,6 +140,7 @@ set(JASSlib_FILES
 	evaluate_price_based_normalized_discounted_cumulative_gain.cpp
 	evaluate_buying_power_normalized_discounted_cumulative_gain.h
 	evaluate_buying_power_normalized_discounted_cumulative_gain.cpp
+	exception_done.h
 	file.h
 	file.cpp
 	forceinline.h

--- a/source/exception_done.h
+++ b/source/exception_done.h
@@ -1,0 +1,22 @@
+/*
+	EXCEPTION_DONE.H
+	----------------
+	Copyright (c) 2023 Vaughan Kitchen
+	Released under the 2-clause BSD license (See:https://en.wikipedia.org/wiki/BSD_licenses)
+*/
+/*!
+	@file
+	@brief Exception to indicate processing has finished and should be early aborted at a greater depth than return handles
+	@author Vaughan Kitchen
+	@copyright 2023 Vaughan Kitchen
+*/
+#pragma once
+
+class Done : public std::exception
+	{
+	public:
+		const char *what()
+			{
+			return "Early return";
+			}
+	};


### PR DESCRIPTION
Cleans things up a bit. Same runtime after testing