### PR TITLE
Fixes a number of build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ endif()
 #
 #	Compatibility with the FileSystem libraries for g++ prior to verison 9
 #
-if(UNIX AND NOT APPLE)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 	message("Adding stdc++fs library for early g++ compatibility")
 	link_libraries(stdc++fs)
 endif()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -16,7 +16,7 @@ include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
 #
 # Versions of externals to download
 #
-set(ZLIB_VERSION "1.3")
+set(ZLIB_VERSION "1.3.2")
 set(ZSTD_VERSION "1.5.7")
 
 

--- a/source/file.h
+++ b/source/file.h
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <string.h>
 
 #ifdef _MSC_VER


### PR DESCRIPTION
1. Missing include on recent g++
2. lld missing symbol in zlib see https://github.com/madler/zlib/issues/856
3. Match compiler instead of OS to build with clang on linux